### PR TITLE
SVY-17113 - Wrong Mantissa Expression passed to Numbro format in NG2

### DIFF
--- a/com.servoy.eclipse.ngclient.ui/node/projects/servoy-public/src/lib/format/formatting.service.ts
+++ b/com.servoy.eclipse.ngclient.ui/node/projects/servoy-public/src/lib/format/formatting.service.ts
@@ -383,8 +383,8 @@ export class FormattingService {
             ret = numbro( data ).format( {
                 thousandSeparated: data > 999 && patchedFormat.includes( ',' ) ? true : false,
                 mantissa: rightDataMantissaLength > minLenMantissa + optionalDigitsMantissa ? minLenMantissa + optionalDigitsMantissa : rightDataMantissaLength < minLenMantissa ? minLenMantissa : rightDataMantissaLength,
-                optionalMantissa: minLenMantissa === 0 && optionalDigitsMantissa >= 0 ? true : false,
-                trimMantissa: optionalDigitsMantissa !== 0,
+                optionalMantissa: minLenMantissa === 0,
+                trimMantissa: minLenMantissa === 0 && optionalDigitsMantissa >= 0 ? true : false,
                 characteristic: minLenCharacteristic + minLenCharacteristicAfterZeroFound,
                 optionalCharacteristic: rightDataMantissaLength === 0 && minLenMantissa === 0 && minLenCharacteristic === 0 && optionalDigitsCharacteristic > 0 
             } );

--- a/com.servoy.eclipse.ngclient.ui/node/projects/servoy-public/src/lib/format/formatting.service.ts
+++ b/com.servoy.eclipse.ngclient.ui/node/projects/servoy-public/src/lib/format/formatting.service.ts
@@ -382,9 +382,9 @@ export class FormattingService {
 
             ret = numbro( data ).format( {
                 thousandSeparated: data > 999 && patchedFormat.includes( ',' ) ? true : false,
-                mantissa: ( rightDataMantissaLength < minLenMantissa + optionalDigitsMantissa ) && optionalDigitsMantissa > 0 ? rightDataMantissaLength : minLenMantissa !== 0 ? minLenMantissa : optionalDigitsMantissa,
-                optionalMantissa: optionalDigitsMantissa !== 0,
-                trimMantissa: minLenMantissa === 0 && optionalDigitsMantissa >= 0 ? true : false,
+                mantissa: rightDataMantissaLength > minLenMantissa + optionalDigitsMantissa ? minLenMantissa + optionalDigitsMantissa : rightDataMantissaLength < minLenMantissa ? minLenMantissa : rightDataMantissaLength,
+                optionalMantissa: minLenMantissa === 0 && optionalDigitsMantissa >= 0 ? true : false,
+                trimMantissa: optionalDigitsMantissa !== 0,
                 characteristic: minLenCharacteristic + minLenCharacteristicAfterZeroFound,
                 optionalCharacteristic: rightDataMantissaLength === 0 && minLenMantissa === 0 && minLenCharacteristic === 0 && optionalDigitsCharacteristic > 0 
             } );


### PR DESCRIPTION
This fixes the issue with the wrong mantissa expressions passed to Numbro, described in ticket [SVY-17113](https://support.servoy.com/browse/SVY-17113).
I believe this matches the expected input according to [Numbro's setMantissaPrecision function](https://github.com/BenjaminVanRyseghem/numbro/blob/5214ac418ed010c6243b08a57141d39e2c5fa733/src/formatting.js#L525).