### PR TITLE
Potential fix for code scanning alert no. 72: Uncontrolled data used in path expression

### DIFF
--- a/com.servoy.eclipse.ui/src/com/servoy/eclipse/ui/wizards/NewSolutionWizardDefaultPackages.java
+++ b/com.servoy.eclipse.ui/src/com/servoy/eclipse/ui/wizards/NewSolutionWizardDefaultPackages.java
@@ -181,9 +181,21 @@ public class NewSolutionWizardDefaultPackages
 	 * @param name the name of the package
 	 * @return a pair containing the version and the package input stream
 	 */
+	private boolean isValidPackageOrSolutionName(String name)
+	{
+		if (name == null || name.length() == 0) return false;
+		if (name.contains("..") || name.indexOf('/') != -1 || name.indexOf('\\') != -1) return false;
+		return name.matches("[A-Za-z0-9._-]+");
+	}
+
 	//public Pair<String, InputStream> getPackage(String name)
 	public Pair<String, File> getPackage(String name)
 	{
+		if (!isValidPackageOrSolutionName(name))
+		{
+			ServoyLog.logError(new IllegalArgumentException("Invalid package/solution name: " + name));
+			return null;
+		}
 		try
 		{
 			if (downloadedPackages.containsKey(name))


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/72](https://github.com/Servoy/servoy-eclipse/security/code-scanning/72)

Use **explicit allowlist validation** for `name` before it is used in any path expression in `getPackage(String name)`.

Best fix (without changing functionality):
- In `com.servoy.eclipse.ui/src/com/servoy/eclipse/ui/wizards/NewSolutionWizardDefaultPackages.java`, add a private validator that only allows expected package/solution name characters (for example letters, digits, `_`, `-`, `.`) and rejects anything containing path separators or `..`.
- Call this validator at the start of `getPackage(String name)`. If invalid, log and return `null`.
- Keep existing logic (`PACKAGES` and `getSolutionsNames()` checks) unchanged, so behavior for valid names remains the same.

This preserves functionality for legitimate package names while blocking traversal/path-manipulation payloads.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
