### PR TITLE
Potential fix for code scanning alert no. 88: Uncontrolled data used in path expression

### DIFF
--- a/com.servoy.eclipse.ui/src/com/servoy/eclipse/ui/wizards/NewSolutionWizardDefaultPackages.java
+++ b/com.servoy.eclipse.ui/src/com/servoy/eclipse/ui/wizards/NewSolutionWizardDefaultPackages.java
@@ -131,7 +131,7 @@ public class NewSolutionWizardDefaultPackages
 		for (JSONObject p : packages)
 		{
 			String name = p.optString("name");
-			if (name != null)
+			if (isSafeFileComponent(name))
 			{
 				if (allPackages.indexOf(name) != -1)
 				{


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/88](https://github.com/Servoy/servoy-eclipse/security/code-scanning/88)

To fix this safely without changing intended behavior, validate `name` with the same strict file-component validator already used for versions (`isSafeFileComponent`) before any path construction. This ensures both created/deleted filenames are composed only of safe characters and cannot include path separators or traversal sequences.

Best single fix in `com.servoy.eclipse.ui/src/com/servoy/eclipse/ui/wizards/NewSolutionWizardDefaultPackages.java`:
- In `setup(...)`, strengthen the existing `if (name != null)` guard to `if (isSafeFileComponent(name))`.
- No new methods are needed because `isSafeFileComponent` already exists and is appropriate.
- No dependency changes are required.

This preserves existing functionality for valid package names while rejecting malformed/untrusted names at the point of use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
