### PR TITLE
Potential fix for code scanning alert no. 40: Inefficient regular expression

### DIFF
--- a/com.servoy.eclipse.ngclient.ui/node/projects/servoy-public/src/lib/format/formatting.service.ts
+++ b/com.servoy.eclipse.ngclient.ui/node/projects/servoy-public/src/lib/format/formatting.service.ts
@@ -468,7 +468,7 @@ export class FormattingService {
         }
         // scientific notation case
         if (servoyFormat.indexOf('E') > -1) {
-            const frmt = /([0#.,]+)+E0+.*/.exec(patchedFormat)[1];
+            const frmt = /([0#.,]+)E0+.*/.exec(patchedFormat)[1];
             let integerDigits = 0;
             let fractionalDigits = 0;
             let countIntegerState = true;


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/40](https://github.com/Servoy/servoy-eclipse/security/code-scanning/40)

The best fix is to remove the nested repetition while preserving matching intent.  
Current pattern: `([0#.,]+)+E0+.*`  
Safer equivalent: `([0#.,]+)E0+.*`

Why this works:
- `([0#.,]+)+` is functionally equivalent to `[0#.,]+` for the matched content, but much less efficient due to ambiguity.
- Replacing it with a single quantifier removes catastrophic backtracking risk and keeps capture group `[1]` behavior needed by `.exec(...)[1]`.

Change needed:
- In `com.servoy.eclipse.ngclient.ui/node/projects/servoy-public/src/lib/format/formatting.service.ts`, around line 471, replace the regex literal only.
- No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
