### PR TITLE
Potential fix for code scanning alert no. 67: Uncontrolled data used in path expression

### DIFF
--- a/com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java
+++ b/com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java
@@ -182,7 +182,13 @@ public class IndexPageFilter implements Filter
 			else
 			{
 				String normalize = Paths.get(requestURI.replace(':', '_')).normalize().toString();
-				File file = new File(distFolder, normalize);
+				File canonicalDistFolder = distFolder.getCanonicalFile();
+				File file = new File(distFolder, normalize).getCanonicalFile();
+				if (!file.toPath().startsWith(canonicalDistFolder.toPath()))
+				{
+					chain.doFilter(servletRequest, servletResponse);
+					return;
+				}
 				String localeId = request.getParameter("localeid");
 				if (requestURI.startsWith("/locales/") && localeId != null && !file.exists())
 				{
@@ -190,8 +196,12 @@ public class IndexPageFilter implements Filter
 					String[] locales = NGLocalesFilter.generateLocaleIds(localeId);
 					for (String locale : locales)
 					{
-						file = new File(distFolder, normalize.replace(localeId, locale));
-						if (file.exists()) break;
+						File candidate = new File(distFolder, normalize.replace(localeId, locale)).getCanonicalFile();
+						if (candidate.toPath().startsWith(canonicalDistFolder.toPath()) && candidate.exists())
+						{
+							file = candidate;
+							break;
+						}
 					}
 				}
 				if (file.exists() && !file.isDirectory() && !file.getName().equals("favicon.ico"))


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/67](https://github.com/Servoy/servoy-eclipse/security/code-scanning/67)

To fix this safely without changing intended behavior, keep resolving requested assets under `distFolder` but enforce that the resolved canonical path remains within the canonical `distFolder` path before serving. This is the standard containment validation for path traversal.

Best single fix in `com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java`:
1. After building `file = new File(distFolder, normalize)`, compute:
   - `File canonicalDistFolder = distFolder.getCanonicalFile();`
   - `File canonicalFile = file.getCanonicalFile();`
2. Reject access unless `canonicalFile.toPath().startsWith(canonicalDistFolder.toPath())`.
3. Use `canonicalFile` for existence/file checks and copy.
4. In locale fallback loop, apply the same canonical containment validation for each candidate before accepting it.

No new dependencies are needed; existing JDK `File#getCanonicalFile()` and `Path#startsWith(...)` are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
