### PR TITLE
Potential fix for code scanning alert no. 49: Uncontrolled command line

### DIFF
--- a/com.servoy.eclipse.debug/src/com/servoy/eclipse/debug/handlers/StartNGDesktopClientHandler.java
+++ b/com.servoy.eclipse.debug/src/com/servoy/eclipse/debug/handlers/StartNGDesktopClientHandler.java
@@ -445,7 +445,21 @@ public class StartNGDesktopClientHandler extends StartDebugHandler implements IR
 			{
 				throw new IOException("Executable does not exist: " + commandPath);
 			}
-			String command = commandPath.toString();
+
+			Path baseRealPath = basePath.toRealPath(LinkOption.NOFOLLOW_LINKS);
+			Path installDirRealPath = installDirPath.toRealPath(LinkOption.NOFOLLOW_LINKS);
+			Path commandRealPath = commandPath.toRealPath(LinkOption.NOFOLLOW_LINKS);
+
+			if (!installDirRealPath.startsWith(baseRealPath))
+			{
+				throw new IOException("Install directory real path escapes base path: " + installDirRealPath);
+			}
+			if (!commandRealPath.startsWith(installDirRealPath))
+			{
+				throw new IOException("Executable real path escapes install directory: " + commandRealPath);
+			}
+
+			String command = commandRealPath.toString();
 			monitor.beginTask("Open NGDesktop", 3);
 
 			ProcessBuilder builder = new ProcessBuilder();


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/49](https://github.com/Servoy/servoy-eclipse/security/code-scanning/49)

The best fix is to enforce a **strict trusted-path policy at execution time** using canonical/real paths and reject symlink/path-manipulation edge cases before invoking `ProcessBuilder`.

In `com.servoy.eclipse.debug/src/com/servoy/eclipse/debug/handlers/StartNGDesktopClientHandler.java` around the launch block (lines ~429–459), strengthen validation by:

- Resolving `basePath`, `installDirPath`, and `commandPath` to **real paths** (`toRealPath(LinkOption.NOFOLLOW_LINKS)` where applicable).
- Ensuring `installDirRealPath.startsWith(baseRealPath)` and `commandRealPath.startsWith(installDirRealPath)`.
- Building the command from the trusted real path (`commandRealPath.toString()`), not from a merely normalized path.
- Keeping existing behavior (same executable selection and platform behavior), only tightening trust checks.

No functionality change is intended; only unsafe edge cases are rejected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
