### PR TITLE
Potential fix for code scanning alert no. 48: Uncontrolled command line

### DIFF
--- a/com.servoy.eclipse.debug/src/com/servoy/eclipse/debug/handlers/StartNGDesktopClientHandler.java
+++ b/com.servoy.eclipse.debug/src/com/servoy/eclipse/debug/handlers/StartNGDesktopClientHandler.java
@@ -459,6 +459,13 @@ public class StartNGDesktopClientHandler extends StartDebugHandler implements IR
 				throw new IOException("Executable real path escapes install directory: " + commandRealPath);
 			}
 
+			String commandName = commandRealPath.getFileName().toString();
+			String expectedCommandName = Utils.isAppleMacOS() ? (NGDESKTOP_APP_NAME + ".app") : (NGDESKTOP_APP_NAME + extension);
+			if (!expectedCommandName.equals(commandName))
+			{
+				throw new IOException("Unexpected executable name: " + commandName);
+			}
+
 			String command = commandRealPath.toString();
 			monitor.beginTask("Open NGDesktop", 3);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/48](https://github.com/Servoy/servoy-eclipse/security/code-scanning/48)

General fix approach: keep using `ProcessBuilder` with separated arguments, but enforce strict allowlisting of what executable/application path can be launched, and ensure untrusted values can only select among expected literals/paths.

Best single fix (without changing functionality): in `StartNGDesktopClientHandler.java`, before calling `builder.command(...)`, add a strict validation that the resolved executable/app path filename is exactly the expected NG Desktop binary/app name for the current OS (`servoyngdesktop` or `servoyngdesktop.app`) and reject anything else. Then keep current execution logic. This complements existing path-boundary checks and addresses CodeQL’s taint concern by proving the launched target is fixed/allowlisted, not arbitrary user-controlled.

Needed changes:
- File: `com.servoy.eclipse.debug/src/com/servoy/eclipse/debug/handlers/StartNGDesktopClientHandler.java`
- Region: around lines 449–473 (path checks + process start)
- Add a small local validation block (or helper method if already shown; here local block is safest with given snippet constraints).
- No new dependency required; use existing JDK APIs already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
