### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete multi-character sanitization

### DIFF
--- a/com.servoy.eclipse.ngclient.ui/node/src/servoycore/session-view/session-view.ts
+++ b/com.servoy.eclipse.ngclient.ui/node/src/servoycore/session-view/session-view.ts
@@ -36,8 +36,13 @@ export class SessionView implements OnInit {
 
             let safeHtml = processedHtml;
 
-            // Remove external scripts from HTML string
-            safeHtml = safeHtml.replace(externalScriptRegex, '');
+            // Remove external scripts from HTML string; repeat until stable to avoid
+            // incomplete multi-character sanitization where new matches can appear.
+            let previousHtml: string;
+            do {
+                previousHtml = safeHtml;
+                safeHtml = safeHtml.replace(externalScriptRegex, '');
+            } while (safeHtml !== previousHtml);
 
             // Bind safe markup
             this.htmlString = this.sanitizer.bypassSecurityTrustHtml(safeHtml);


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/12](https://github.com/Servoy/servoy-eclipse/security/code-scanning/12)

To fix this safely without changing intended functionality, make script-stripping **iterative until stable** (fixed point), instead of a single pass. This directly addresses incomplete multi-character sanitization: if one removal pass reveals another match, subsequent passes remove it as well.

Best approach in this file:
- In `ngOnInit` around the current line 40 logic, replace the one-time `safeHtml.replace(externalScriptRegex, '')` with a `do...while` loop that keeps applying the same global regex until no changes occur.
- Keep existing behavior otherwise:
  - still process placeholders,
  - still remove external scripts from bound HTML,
  - still re-inject extracted external scripts with nonce from `processedHtml`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
