### PR TITLE
Potential fix for code scanning alert no. 47: URL redirection from remote source

### DIFF
--- a/com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java
+++ b/com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java
@@ -138,7 +138,17 @@ public class IndexPageFilter implements Filter
 						if (showLogin.getRight() == null) return; // oauth was successful but the cloud returned html
 						request.getSession().setAttribute(StatelessLoginHandler.ID_TOKEN, showLogin.getRight());
 						String queryString = StatelessLoginUtils.checkForPossibleSavedDeeplink(request);
-						response.sendRedirect(request.getRequestURI().replace("/svy_oauth", "") + (queryString != null ? "?" + queryString : ""));
+						String redirectBasePath = request.getRequestURI().replace("/svy_oauth", "");
+						String redirectTarget = redirectBasePath + (queryString != null ? "?" + queryString : "");
+						if (!redirectTarget.startsWith("/") || redirectTarget.startsWith("//") || redirectTarget.contains("://") ||
+							redirectTarget.indexOf('\r') != -1 || redirectTarget.indexOf('\n') != -1)
+						{
+							response.sendRedirect(redirectBasePath.startsWith("/") ? redirectBasePath : "/");
+						}
+						else
+						{
+							response.sendRedirect(redirectTarget);
+						}
 						return;
 					}
 				}

--- a/com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java
+++ b/com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java
@@ -139,16 +139,15 @@ public class IndexPageFilter implements Filter
 						request.getSession().setAttribute(StatelessLoginHandler.ID_TOKEN, showLogin.getRight());
 						String queryString = StatelessLoginUtils.checkForPossibleSavedDeeplink(request);
 						String redirectBasePath = request.getRequestURI().replace("/svy_oauth", "");
-						String redirectTarget = redirectBasePath + (queryString != null ? "?" + queryString : "");
-						if (!redirectTarget.startsWith("/") || redirectTarget.startsWith("//") || redirectTarget.contains("://") ||
-							redirectTarget.indexOf('\r') != -1 || redirectTarget.indexOf('\n') != -1)
+						if (!redirectBasePath.startsWith("/") || redirectBasePath.startsWith("//"))
 						{
-							response.sendRedirect(redirectBasePath.startsWith("/") ? redirectBasePath : "/");
+							redirectBasePath = "/";
 						}
-						else
-						{
-							response.sendRedirect(redirectTarget);
-						}
+
+						boolean hasSafeQuery = queryString != null && queryString.indexOf('\r') == -1 && queryString.indexOf('\n') == -1 &&
+							!queryString.startsWith("//") && !queryString.contains("://");
+						String redirectTarget = hasSafeQuery ? (redirectBasePath + "?" + queryString) : redirectBasePath;
+						response.sendRedirect(redirectTarget);
 						return;
 					}
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-eclipse/security/code-scanning/47](https://github.com/Servoy/servoy-eclipse/security/code-scanning/47)

Best fix: ensure the redirect target is strictly a **relative in-app path** and reject any absolute/protocol-relative/newline-injected values before calling `sendRedirect`.

In `com.servoy.eclipse.ngclient.ui/src/com/servoy/eclipse/ngclient/ui/IndexPageFilter.java`, replace the current line 141 redirect construction with:
1. Build the base path from `request.getRequestURI().replace("/svy_oauth", "")`.
2. Build the full target with optional query string.
3. Validate target is safe:
   - starts with `/`
   - does not start with `//`
   - does not contain `\r` or `\n`
   - does not contain `"://"` (absolute URL indicator)
4. If validation fails, redirect to a safe local fallback (for example, the sanitized base path or `/`).
5. Otherwise redirect to the validated target.

No new dependencies are needed; no import changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
